### PR TITLE
Bugfix: remove extra newlines

### DIFF
--- a/src/lib/ECPay.Payment.Integration.php
+++ b/src/lib/ECPay.Payment.Integration.php
@@ -1642,7 +1642,3 @@ class ECPay_CheckMacValue{
     }
 
 }
-
-
-?>
-


### PR DESCRIPTION
Remove extra newlines introduced in `ECPay.Payment.Integration.php`. This fix the problem of getting an extra `\n` when calling getResponse().